### PR TITLE
Stage current changes

### DIFF
--- a/image_transport/include/image_transport/camera_subscriber.h
+++ b/image_transport/include/image_transport/camera_subscriber.h
@@ -38,6 +38,7 @@
 #include <functional>
 
 #include <rclcpp/node.hpp>
+#include <rclcpp/subscription_options.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -71,12 +72,18 @@ public:
   IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber() = default;
 
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   IMAGE_TRANSPORT_PUBLIC
-  CameraSubscriber(rclcpp::Node * node,
-                   const std::string& base_topic,
-                   const Callback& callback,
-                   const std::string& transport,
-                   rmw_qos_profile_t = rmw_qos_profile_default);
+  CameraSubscriber(
+    rclcpp::Node* node,
+    const std::string & base_topic,
+    const std::string & transport,
+    const rclcpp::QoS & qos,
+    const Callback& callback,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat);
 
   /**
    * \brief Get the base topic (on which the raw image is published).

--- a/image_transport/include/image_transport/image_transport.h
+++ b/image_transport/include/image_transport/image_transport.h
@@ -64,13 +64,18 @@ Publisher create_publisher(
 /**
  * \brief Subscribe to an image topic, free function version.
  */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
 IMAGE_TRANSPORT_PUBLIC
 Subscriber create_subscription(
   rclcpp::Node* node,
   const std::string & base_topic,
-  const Subscriber::Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  const rclcpp::QoS & qos,
+  const Subscriber::Callback & callback,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat);
 
 /*!
  * \brief Advertise a camera, free function version.
@@ -137,52 +142,80 @@ public:
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     const Subscriber::Callback & callback,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat,
     const VoidPtr & tracked_object = VoidPtr(),
     const TransportHints * transport_hints = nullptr);
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
+  template<
+      typename AllocatorT,
+      typename MessageMemoryStrategyT>
   IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (*fp)(const ImageConstPtr &),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat,
     const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, queue_size,
+    return subscribe(base_topic, qos,
              std::function<void(const ImageConstPtr &)>(fp),
+             options, msg_mem_strat,
              VoidPtr(), transport_hints);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with bare pointer.
    */
-  template<class T>
+  template<
+      typename AllocatorT,
+      typename MessageMemoryStrategyT,
+      class T>
   Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (T::* fp)(const ImageConstPtr &), T * obj,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat,
     const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
+    return subscribe(base_topic, qos, std::bind(fp, obj, std::placeholders::_1),
+             options, msg_mem_strat,
              VoidPtr(), transport_hints);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with shared_ptr.
    */
-  template<class T>
+  template<
+      typename AllocatorT,
+      typename MessageMemoryStrategyT,
+      class T>
   Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (T::* fp)(const ImageConstPtr &),
     const std::shared_ptr<T> & obj,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat,
     const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, queue_size, std::bind(fp,
-             obj.get(), std::placeholders::_1), obj, transport_hints);
+    return subscribe(base_topic, qos, std::bind(fp,
+             obj.get(), std::placeholders::_1),
+             options, msg_mem_strat,
+             obj, transport_hints);
   }
 
   /*!

--- a/image_transport/include/image_transport/simple_subscriber_plugin.h
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.h
@@ -111,21 +111,27 @@ protected:
     return base_topic + "/" + getTransportName();
   }
 
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   virtual void subscribeImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
+    const rclcpp::QoS & qos,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos)
+    const SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
     impl_ = std::make_unique<Impl>();
     // Push each group of transport-specific parameters into a separate sub-namespace
     //ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
-    //
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos));
+
     impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), qos,
         [this, callback](const typename std::shared_ptr<const M> msg){
           internalCallback(msg, callback);
-        });
+        },
+        options,
+        msg_mem_strat);
   }
 
 private:

--- a/image_transport/include/image_transport/subscriber.h
+++ b/image_transport/include/image_transport/subscriber.h
@@ -36,6 +36,7 @@
 #define IMAGE_TRANSPORT_SUBSCRIBER_H
 
 #include <rclcpp/node.hpp>
+#include <rclcpp/subscription_options.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include "image_transport/exception.h"
@@ -68,14 +69,19 @@ public:
   IMAGE_TRANSPORT_PUBLIC
   Subscriber() = default;
 
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   IMAGE_TRANSPORT_PUBLIC
   Subscriber(
-    rclcpp::Node * node,
+    rclcpp::Node* node,
     const std::string & base_topic,
-    const Callback & callback,
-    SubLoaderPtr loader,
     const std::string & transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const rclcpp::QoS & qos,
+    const Subscriber::Callback & callback,
+    SubLoaderPtr loader,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat);
 
   /**
    * \brief Returns the base image topic.

--- a/image_transport/include/image_transport/subscriber_filter.h
+++ b/image_transport/include/image_transport/subscriber_filter.h
@@ -36,6 +36,7 @@
 #define IMAGE_TRANSPORT_SUBSCRIBER_FILTER_H
 
 #include <message_filters/simple_filter.h>
+#include <rclcpp/subscription_options.hpp>
 #include "image_transport/image_transport.h"
 #include "image_transport/visibility_control.hpp"
 
@@ -76,11 +77,18 @@ public:
    * \param transport The transport hint to pass along
    */
   IMAGE_TRANSPORT_PUBLIC
+  template<
+      typename AllocatorT,
+      typename MessageMemoryStrategyT>
   SubscriberFilter(
-    rclcpp::Node * node, const std::string & base_topic,
-    const std::string & transport)
+    rclcpp::Node* node,
+    const std::string & base_topic,
+    const std::string & transport,
+    const rclcpp::QoS & qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
-    subscribe(node, base_topic, transport);
+    subscribe(node, base_topic, transport, qos, options, msg_mem_strat);
   }
 
   /**
@@ -105,17 +113,23 @@ public:
    * \param nh The ros::NodeHandle to use to subscribe.
    * \param base_topic The topic to subscribe to.
    */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   IMAGE_TRANSPORT_PUBLIC
   void subscribe(
     rclcpp::Node * node,
     const std::string & base_topic,
     const std::string & transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
     unsubscribe();
     sub_ =
-      image_transport::create_subscription(node, base_topic,
-        std::bind(&SubscriberFilter::cb, this, std::placeholders::_1), transport, custom_qos);
+      image_transport::create_subscription(node, base_topic, transport, qos,
+        std::bind(&SubscriberFilter::cb, this, std::placeholders::_1),
+        options, msg_mem_strat);
   }
 
   /**

--- a/image_transport/include/image_transport/subscriber_plugin.h
+++ b/image_transport/include/image_transport/subscriber_plugin.h
@@ -37,6 +37,7 @@
 
 #include <rclcpp/macros.hpp>
 #include <rclcpp/node.hpp>
+#include <rclcpp/subscription_options.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include "image_transport/visibility_control.hpp"
@@ -67,52 +68,78 @@ public:
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
-    return subscribeImpl(node, base_topic, callback, custom_qos);
+    return subscribeImpl(node, base_topic, qos, callback, options, msg_mem_strat);
   }
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
-    return subscribe(node, base_topic,
+    return subscribe(node, base_topic, qos,
              std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr &)>(fp),
-             custom_qos);
+             options, msg_mem_strat);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with bare pointer.
    */
-  template<class T>
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT,
+    class T>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &), T * obj,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
-    return subscribe(node, base_topic,
-             std::bind(fp, obj, std::placeholders::_1), custom_qos);
+    return subscribe(node, base_topic, qos,
+             std::bind(fp, obj, std::placeholders::_1),
+             options, msg_mem_strat);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with shared_ptr.
    */
-  template<class T>
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT,
+    class T>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
     std::shared_ptr<T> & obj,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
   {
-    return subscribe(node, base_topic,
-             std::bind(fp, obj, std::placeholders::_1), custom_qos);
+    return subscribe(node, base_topic, qos,
+             std::bind(fp, obj, std::placeholders::_1),
+             options, msg_mem_strat);
   }
 
   /**
@@ -143,10 +170,16 @@ protected:
   /**
    * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
    */
+  template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
   virtual void subscribeImpl(
-    rclcpp::Node * node, const std::string & base_topic,
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const rclcpp::QoS & qos,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat) = 0;
 };
 
 } //namespace image_transport

--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -108,12 +108,17 @@ struct CameraSubscriber::Impl
   int image_received_, info_received_, both_received_;
 };
 
+template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
 CameraSubscriber::CameraSubscriber(
-  rclcpp::Node * node,
-  const std::string & base_topic,
-  const Callback & callback,
-  const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+    rclcpp::Node* node,
+    const std::string & base_topic,
+    const std::string & transport,
+    const rclcpp::QoS & qos,
+    const CameraSubscriber::Callback & callback,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
 : impl_(std::make_shared<Impl>(node))
 {
   // Must explicitly remap the image topic since we then do some string manipulation on it
@@ -122,8 +127,8 @@ CameraSubscriber::CameraSubscriber(
       node->get_name(), node->get_namespace());
   std::string info_topic = getCameraInfoTopic(image_topic);
 
-  impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
-  impl_->info_sub_.subscribe(node, info_topic, custom_qos);
+  impl_->image_sub_.subscribe(node, image_topic, transport, qos, options, msg_mem_strat);
+  impl_->info_sub_.subscribe(node, info_topic, qos, options, msg_mem_strat);
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);
   impl_->sync_.registerCallback(std::bind(callback, std::placeholders::_1, std::placeholders::_2));

--- a/image_transport/src/subscriber.cpp
+++ b/image_transport/src/subscriber.cpp
@@ -82,13 +82,18 @@ struct Subscriber::Impl
   //double constructed_;
 };
 
+template<
+    typename AllocatorT,
+    typename MessageMemoryStrategyT>
 Subscriber::Subscriber(
-  rclcpp::Node * node,
+  rclcpp::Node* node,
   const std::string & base_topic,
-  const Callback & callback,
-  SubLoaderPtr loader,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & qos,
+  const Subscriber::Callback & callback,
+  SubLoaderPtr loader,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
 : impl_(std::make_shared<Impl>(node, loader))
 {
   // Load the plugin for the chosen transport.
@@ -124,7 +129,7 @@ Subscriber::Subscriber(
 
   // Tell plugin to subscribe.
   RCLCPP_DEBUG(impl_->logger_, "Subscribing to: %s\n", base_topic.c_str());
-  impl_->subscriber_->subscribe(node, base_topic, callback, custom_qos);
+  impl_->subscriber_->subscribe(node, base_topic, qos, callback, options, msg_mem_strat);
 }
 
 std::string Subscriber::getTopic() const


### PR DESCRIPTION
Ping @mjcarroll @marguedas , for this real rough start

I don't really use templates, and as they can't seem to be used with virtual functions, nor do I understand the convention user pattern of optional arguments over this codebase, I'd like to ask how to proceed with respect to the post I raised in:

https://discourse.ros.org/t/adding-image-transport-message-filter-subscription-to-callback-group/12413

* Also, should we attempt to surface the MessageMemoryStrategy argument as well?
* How should we parameterized the CameraSubscriber, that creates subscribers for two subscriptions, image transport and camera info?
* Is there a better approach for refactoring this not just for subscribers, but for things like publisher related functions as well? Perhaps a custom helper class that containers the qos/memory settings for image or camera transports?

We can move this discussion to a ros-perception/image_common ticket, I just wanted to link this hairball.